### PR TITLE
Add module and site enable and disable commands

### DIFF
--- a/bin/droid-apache
+++ b/bin/droid-apache
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Application;
+
+use Droid\Plugin\Apache\DroidPlugin;
+
+$loader = __DIR__ . '/../vendor/autoload.php';
+
+if (!file_exists($loader)) {
+    $loader = __DIR__ . '/../../../autoload.php';
+}
+
+if (!file_exists($loader)) {
+    die(
+        'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
+
+require $loader;
+
+$application = new Application('Droid Apache', '1.0.0');
+$application->setCatchExceptions(true);
+$registry = new DroidPlugin($application);
+foreach ($registry->getCommands() as $command) {
+    $application->add($command);
+}
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
             "Droid\\Plugin\\Apache\\": "src/"
         }
     },
+    "bin": [
+        "bin/droid-apache"
+    ],
     "license": "MIT"
 }

--- a/src/Command/AbstractApacheCommand.php
+++ b/src/Command/AbstractApacheCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Droid\Plugin\Apache\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Util\Normaliser;
+
+abstract class AbstractApacheCommand extends Command
+{
+    private $processBuilder;
+    private $normaliser;
+    private $confDir;
+
+    public function __construct(
+        ProcessBuilder $processBuilder,
+        Normaliser $normaliser,
+        $configDirectory = '/etc/apache2',
+        $name = null
+    ) {
+        $this->processBuilder = $processBuilder;
+        $this->normaliser = $normaliser;
+        $this->confDir = $configDirectory;
+        return parent::__construct($name);
+    }
+
+    abstract protected function getEnabledDir();
+    abstract protected function getAvailableDir();
+
+    protected function getConfName($argument)
+    {
+        return $this->normaliser->normaliseConfName($argument);
+    }
+
+    protected function getConfFilename($argument)
+    {
+        return $this->normaliser->normaliseConfFilename($argument);
+    }
+
+    protected function available($confFilename)
+    {
+        $p = $this->getProcess(
+            array(
+                'stat',
+                '-c',
+                '%F',
+                $this->getTargetPath($confFilename)
+            )
+        );
+        if (!$p->run()
+            && preg_match('/^regular(?: empty)? file/', $p->getOutput())
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    protected function enabled($confFilename)
+    {
+        $p = $this->getProcess(
+            array(
+                'stat',
+                '-c',
+                '%F',
+                $this->getLinkPath($confFilename)
+            )
+        );
+        if (!$p->run()
+            && substr($p->getOutput(), 0, 13) === 'symbolic link'
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    protected function enable($confFilename)
+    {
+        $p = $this->getProcess(
+            array(
+                'ln',
+                '-s',
+                $this->getTargetPath($confFilename),
+                $this->getLinkPath($confFilename),
+            )
+        );
+        return $p->run() === 0;
+    }
+
+    protected function disable($confFilename)
+    {
+        $p = $this->getProcess(
+            array(
+                'unlink',
+                $this->getLinkPath($confFilename),
+            )
+        );
+        return $p->run() === 0;
+    }
+
+    private function getLinkPath($confFilename)
+    {
+        return implode(
+            DIRECTORY_SEPARATOR,
+            array(
+                $this->confDir,
+                $this->getEnabledDir(),
+                $confFilename,
+            )
+        );
+    }
+
+    private function getTargetPath($confFilename)
+    {
+        return implode(
+            DIRECTORY_SEPARATOR,
+            array(
+                $this->confDir,
+                $this->getAvailableDir(),
+                $confFilename,
+            )
+        );
+    }
+
+    private function getProcess($arguments)
+    {
+        return $this
+            ->processBuilder
+            ->setArguments($arguments)
+            ->getProcess()
+        ;
+    }
+}

--- a/src/Command/ApacheModuleDisableCommand.php
+++ b/src/Command/ApacheModuleDisableCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Droid\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class ApacheModuleDisableCommand extends AbstractApacheCommand
+{
+    use CheckableTrait;
+
+    protected $enabledDir = 'mods-enabled';
+    protected $availableDir = 'mods-available';
+
+    public function configure()
+    {
+        $this
+            ->setName('apache:dismod')
+            ->setDescription('Disable Apache modules.')
+            ->addArgument(
+                'module-name',
+                InputArgument::REQUIRED,
+                'Disable the named module.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $confname = $this->getConfName($input->getArgument('module-name'));
+        $confFilename = $this->getConfFilename($input->getArgument('module-name'));
+
+        if (! $this->available($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I am not aware of a module named "%s".', $confname)
+            );
+        }
+
+        if (! $this->enabled($confFilename)) {
+            $output->writeLn(
+                sprintf(
+                    'The module "%s" is already disabled. Nothing to do.',
+                    $confname
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $this->markChange();
+
+        if (! $this->checkMode() && ! $this->disable($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I cannot disable module "%s".', $confname)
+            );
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s "%s".',
+                $this->checkMode() ? 'would disable' : 'have disabled',
+                $confname
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    protected function getAvailableDir()
+    {
+        return $this->availableDir;
+    }
+
+    protected function getEnabledDir()
+    {
+        return $this->enabledDir;
+    }
+}

--- a/src/Command/ApacheModuleEnableCommand.php
+++ b/src/Command/ApacheModuleEnableCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Droid\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class ApacheModuleEnableCommand extends AbstractApacheCommand
+{
+    use CheckableTrait;
+
+    protected $enabledDir = 'mods-enabled';
+    protected $availableDir = 'mods-available';
+
+    public function configure()
+    {
+        $this
+            ->setName('apache:enmod')
+            ->setDescription('Enable Apache modules.')
+            ->addArgument(
+                'module-name',
+                InputArgument::REQUIRED,
+                'Enable the named module.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $confname = $this->getConfName($input->getArgument('module-name'));
+        $confFilename = $this->getConfFilename($input->getArgument('module-name'));
+
+        if (! $this->available($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I am not aware of a module named "%s".', $confname)
+            );
+        }
+
+        if ($this->enabled($confFilename)) {
+            $output->writeLn(
+                sprintf(
+                    'The module "%s" is already enabled. Nothing to do.',
+                    $confname
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $this->markChange();
+
+        if (! $this->checkMode() && ! $this->enable($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I cannot enable module "%s".', $confname)
+            );
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s "%s".',
+                $this->checkMode() ? 'would enable' : 'have enabled',
+                $confname
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    protected function getAvailableDir()
+    {
+        return $this->availableDir;
+    }
+
+    protected function getEnabledDir()
+    {
+        return $this->enabledDir;
+    }
+}

--- a/src/Command/ApacheSiteDisableCommand.php
+++ b/src/Command/ApacheSiteDisableCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Droid\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class ApacheSiteDisableCommand extends AbstractApacheCommand
+{
+    use CheckableTrait;
+
+    protected $enabledDir = 'sites-enabled';
+    protected $availableDir = 'sites-available';
+
+    public function configure()
+    {
+        $this
+            ->setName('apache:dissite')
+            ->setDescription('Disable Apache sites.')
+            ->addArgument(
+                'site-name',
+                InputArgument::REQUIRED,
+                'Disable the named site.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $confname = $this->getConfName($input->getArgument('site-name'));
+        $confFilename = $this->getConfFilename($input->getArgument('site-name'));
+
+        if (! $this->available($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I am not aware of a site named "%s".', $confname)
+            );
+        }
+
+        if (! $this->enabled($confFilename)) {
+            $output->writeLn(
+                sprintf(
+                    'The site "%s" is already disabled. Nothing to do.',
+                    $confname
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $this->markChange();
+
+        if (! $this->checkMode() && ! $this->disable($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I cannot disable site "%s".', $confname)
+            );
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s "%s".',
+                $this->checkMode() ? 'would disable' : 'have disabled',
+                $confname
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    protected function getAvailableDir()
+    {
+        return $this->availableDir;
+    }
+
+    protected function getEnabledDir()
+    {
+        return $this->enabledDir;
+    }
+}

--- a/src/Command/ApacheSiteEnableCommand.php
+++ b/src/Command/ApacheSiteEnableCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Droid\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class ApacheSiteEnableCommand extends AbstractApacheCommand
+{
+    use CheckableTrait;
+
+    protected $enabledDir = 'sites-enabled';
+    protected $availableDir = 'sites-available';
+
+    public function configure()
+    {
+        $this
+            ->setName('apache:ensite')
+            ->setDescription('Enable Apache sites.')
+            ->addArgument(
+                'site-name',
+                InputArgument::REQUIRED,
+                'Enable the named site.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $confname = $this->getConfName($input->getArgument('site-name'));
+        $confFilename = $this->getConfFilename($input->getArgument('site-name'));
+
+        if (! $this->available($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I am not aware of a site named "%s".', $confname)
+            );
+        }
+
+        if ($this->enabled($confFilename)) {
+            $output->writeLn(
+                sprintf(
+                    'The site "%s" is already enabled. Nothing to do.',
+                    $confname
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $this->markChange();
+
+        if (! $this->checkMode() && ! $this->enable($confFilename)) {
+            throw new RuntimeException(
+                sprintf('I cannot enable site "%s".', $confname)
+            );
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s "%s".',
+                $this->checkMode() ? 'would enable' : 'have enabled',
+                $confname
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    protected function getAvailableDir()
+    {
+        return $this->availableDir;
+    }
+
+    protected function getEnabledDir()
+    {
+        return $this->enabledDir;
+    }
+}

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -6,6 +6,8 @@ use Symfony\Component\Process\ProcessBuilder;
 
 use Droid\Plugin\Apache\Command\ApacheModuleDisableCommand;
 use Droid\Plugin\Apache\Command\ApacheModuleEnableCommand;
+use Droid\Plugin\Apache\Command\ApacheSiteDisableCommand;
+use Droid\Plugin\Apache\Command\ApacheSiteEnableCommand;
 use Droid\Plugin\Apache\Util\Normaliser;
 
 class DroidPlugin
@@ -23,6 +25,14 @@ class DroidPlugin
                 new Normaliser
             ),
             new ApacheModuleEnableCommand(
+                new ProcessBuilder,
+                new Normaliser
+            ),
+            new ApacheSiteDisableCommand(
+                new ProcessBuilder,
+                new Normaliser
+            ),
+            new ApacheSiteEnableCommand(
                 new ProcessBuilder,
                 new Normaliser
             ),

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -2,6 +2,12 @@
 
 namespace Droid\Plugin\Apache;
 
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Command\ApacheModuleDisableCommand;
+use Droid\Plugin\Apache\Command\ApacheModuleEnableCommand;
+use Droid\Plugin\Apache\Util\Normaliser;
+
 class DroidPlugin
 {
     public function __construct($droid)
@@ -12,6 +18,14 @@ class DroidPlugin
     public function getCommands()
     {
         return array(
+            new ApacheModuleDisableCommand(
+                new ProcessBuilder,
+                new Normaliser
+            ),
+            new ApacheModuleEnableCommand(
+                new ProcessBuilder,
+                new Normaliser
+            ),
         );
     }
 }

--- a/src/Util/Normaliser.php
+++ b/src/Util/Normaliser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Droid\Plugin\Apache\Util;
+
+class Normaliser
+{
+    public function normaliseConfName($confName)
+    {
+        if (substr($confName, -5, 5) === '.conf') {
+            return substr($confName, 0, -5);
+        }
+        return $confName;
+    }
+
+    public function normaliseConfFilename($confName)
+    {
+        if (substr($confName, -5, 5) != '.conf') {
+            return $confName . '.conf';
+        }
+        return $confName;
+    }
+}

--- a/test/Command/ApacheModuleDisableCommandTest.php
+++ b/test/Command/ApacheModuleDisableCommandTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Droid\Test\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Command\ApacheModuleDisableCommand;
+use Droid\Plugin\Apache\Util\Normaliser;
+
+class ApacheModuleDisableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $tester;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+        $this
+            ->processBuilder
+            ->method('setArguments')
+            ->willReturnSelf()
+        ;
+        $this
+            ->processBuilder
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+
+        $command = new ApacheModuleDisableCommand(
+            $this->processBuilder,
+            new Normaliser
+        );
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I am not aware of a module named "not_a_module"
+     */
+    public function testApacheModDisableThrowsRuntimeExceptionWithUnknownModule()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/not_a_module.conf',
+                )
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(1)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dismod')->getName(),
+            'module-name' => 'not_a_module',
+        ));
+    }
+
+    public function testApacheModDisableExitsWhenModuleIsAlreadyDisabled()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dismod')->getName(),
+            'module-name' => 'a_module',
+        ));
+
+
+        $this->assertRegExp(
+            '/^The module "a_module" is already disabled\. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I cannot disable module "a_module"
+     */
+    public function testApacheModDisableThrowsRuntimeExceptionWhenFailsToDisable()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                )),
+                array(array(
+                    'unlink',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dismod')->getName(),
+            'module-name' => 'a_module',
+        ));
+    }
+
+    public function testApacheModDisableWillDisableEnabledModule()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                )),
+                array(array(
+                    'unlink',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dismod')->getName(),
+            'module-name' => 'a_module',
+        ));
+
+
+        $this->assertRegExp(
+            '/^I have disabled "a_module"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testApacheModDisableWillReportOnlyInCheckMode()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf'
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf'
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dismod')->getName(),
+            'module-name' => 'a_module',
+            '--check' => true,
+        ));
+
+
+        $this->assertRegExp(
+            '/^I would disable "a_module"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/Command/ApacheModuleEnableCommandTest.php
+++ b/test/Command/ApacheModuleEnableCommandTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Droid\Test\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Command\ApacheModuleEnableCommand;
+use Droid\Plugin\Apache\Util\Normaliser;
+
+class ApacheModuleEnableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $tester;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+        $this
+            ->processBuilder
+            ->method('setArguments')
+            ->willReturnSelf()
+        ;
+        $this
+            ->processBuilder
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+
+        $command = new ApacheModuleEnableCommand(
+            $this->processBuilder,
+            new Normaliser
+        );
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I am not aware of a module named "not_a_module"
+     */
+    public function testApacheModEnableThrowsRuntimeExceptionWithUnknownModule()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/not_a_module.conf'
+                )
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(1)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:enmod')->getName(),
+            'module-name' => 'not_a_module',
+        ));
+    }
+
+    public function testApacheModEnableExitsWhenModuleIsAlreadyEnabled()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:enmod')->getName(),
+            'module-name' => 'a_module',
+        ));
+
+
+        $this->assertRegExp(
+            '/^The module "a_module" is already enabled\. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I cannot enable module "a_module"
+     */
+    public function testApacheModEnableThrowsRuntimeExceptionWhenFailsToEnable()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                )),
+                array(array(
+                    'ln',
+                    '-s',
+                    '/etc/apache2/mods-available/a_module.conf',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:enmod')->getName(),
+            'module-name' => 'a_module',
+        ));
+    }
+
+    public function testApacheModEnableWillEnableDisabledModule()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                )),
+                array(array(
+                    'ln',
+                    '-s',
+                    '/etc/apache2/mods-available/a_module.conf',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:enmod')->getName(),
+            'module-name' => 'a_module',
+        ));
+
+
+        $this->assertRegExp(
+            '/^I have enabled "a_module"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testApacheModEnableWillReportOnlyInCheckMode()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-available/a_module.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/mods-enabled/a_module.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:enmod')->getName(),
+            'module-name' => 'a_module',
+            '--check' => true,
+        ));
+
+
+        $this->assertRegExp(
+            '/^I would enable "a_module"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/Command/ApacheSiteDisableCommandTest.php
+++ b/test/Command/ApacheSiteDisableCommandTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Droid\Test\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Command\ApacheSiteDisableCommand;
+use Droid\Plugin\Apache\Util\Normaliser;
+
+class ApacheSiteDisableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $tester;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+        $this
+            ->processBuilder
+            ->method('setArguments')
+            ->willReturnSelf()
+        ;
+        $this
+            ->processBuilder
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+
+        $command = new ApacheSiteDisableCommand(
+            $this->processBuilder,
+            new Normaliser
+        );
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I am not aware of a site named "not_a_site"
+     */
+    public function testApacheSiteDisableThrowsRuntimeExceptionWithUnknownSite()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/not_a_site.conf',
+                )
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(1)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dissite')->getName(),
+            'site-name' => 'not_a_site',
+        ));
+    }
+
+    public function testApacheSiteDisableExitsWhenSiteIsAlreadyDisabled()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dissite')->getName(),
+            'site-name' => 'a_site',
+        ));
+
+
+        $this->assertRegExp(
+            '/^The site "a_site" is already disabled\. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I cannot disable site "a_site"
+     */
+    public function testApacheSiteDisableThrowsRuntimeExceptionWhenFailsToDisable()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                )),
+                array(array(
+                    'unlink',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dissite')->getName(),
+            'site-name' => 'a_site',
+        ));
+    }
+
+    public function testApacheSiteDisableWillDisableEnabledSite()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                )),
+                array(array(
+                    'unlink',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dissite')->getName(),
+            'site-name' => 'a_site',
+        ));
+
+
+        $this->assertRegExp(
+            '/^I have disabled "a_site"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testApacheSiteDisableWillReportOnlyInCheckMode()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf'
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf'
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:dissite')->getName(),
+            'site-name' => 'a_site',
+            '--check' => true,
+        ));
+
+
+        $this->assertRegExp(
+            '/^I would disable "a_site"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/Command/ApacheSiteEnableCommandTest.php
+++ b/test/Command/ApacheSiteEnableCommandTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Droid\Test\Plugin\Apache\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Apache\Command\ApacheSiteEnableCommand;
+use Droid\Plugin\Apache\Util\Normaliser;
+
+class ApacheSiteEnableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $tester;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+        $this
+            ->processBuilder
+            ->method('setArguments')
+            ->willReturnSelf()
+        ;
+        $this
+            ->processBuilder
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+
+        $command = new ApacheSiteEnableCommand(
+            $this->processBuilder,
+            new Normaliser
+        );
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I am not aware of a site named "not_a_site"
+     */
+    public function testApacheSiteEnableThrowsRuntimeExceptionWithUnknownSite()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/not_a_site.conf'
+                )
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(1)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:ensite')->getName(),
+            'site-name' => 'not_a_site',
+        ));
+    }
+
+    public function testApacheSiteEnableExitsWhenSiteIsAlreadyEnabled()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturnOnConsecutiveCalls('regular file', 'symbolic link')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:ensite')->getName(),
+            'site-name' => 'a_site',
+        ));
+
+
+        $this->assertRegExp(
+            '/^The site "a_site" is already enabled\. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I cannot enable site "a_site"
+     */
+    public function testApacheSiteEnableThrowsRuntimeExceptionWhenFailsToEnable()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                )),
+                array(array(
+                    'ln',
+                    '-s',
+                    '/etc/apache2/sites-available/a_site.conf',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:ensite')->getName(),
+            'site-name' => 'a_site',
+        ));
+    }
+
+    public function testApacheSiteEnableWillEnableDisabledSite()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(3))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                )),
+                array(array(
+                    'ln',
+                    '-s',
+                    '/etc/apache2/sites-available/a_site.conf',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(3))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1, 0)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:ensite')->getName(),
+            'site-name' => 'a_site',
+        ));
+
+
+        $this->assertRegExp(
+            '/^I have enabled "a_site"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testApacheSiteEnableWillReportOnlyInCheckMode()
+    {
+        $this
+            ->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-available/a_site.conf',
+                )),
+                array(array(
+                    'stat',
+                    '-c',
+                    '%F',
+                    '/etc/apache2/sites-enabled/a_site.conf',
+                ))
+            )
+        ;
+        $this
+            ->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(0, 1)
+        ;
+        $this
+            ->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('regular file')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('apache:ensite')->getName(),
+            'site-name' => 'a_site',
+            '--check' => true,
+        ));
+
+
+        $this->assertRegExp(
+            '/^I would enable "a_site"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/DroidPluginTest.php
+++ b/test/DroidPluginTest.php
@@ -19,6 +19,8 @@ class DroidPluginTest extends \PHPUnit_Framework_TestCase
             array(
                 'Droid\Plugin\Apache\Command\ApacheModuleDisableCommand',
                 'Droid\Plugin\Apache\Command\ApacheModuleEnableCommand',
+                'Droid\Plugin\Apache\Command\ApacheSiteDisableCommand',
+                'Droid\Plugin\Apache\Command\ApacheSiteEnableCommand',
             ),
             array_map(
                 function ($x) {

--- a/test/DroidPluginTest.php
+++ b/test/DroidPluginTest.php
@@ -17,6 +17,8 @@ class DroidPluginTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame(
             array(
+                'Droid\Plugin\Apache\Command\ApacheModuleDisableCommand',
+                'Droid\Plugin\Apache\Command\ApacheModuleEnableCommand',
             ),
             array_map(
                 function ($x) {

--- a/test/Util/NormaliserTest.php
+++ b/test/Util/NormaliserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Droid\Test\Plugin\Apache\Util;
+
+use Droid\Plugin\Apache\Util\Normaliser;
+
+class NormaliserTest extends \PHPUnit_Framework_TestCase
+{
+    protected $norm;
+
+    protected function setUp()
+    {
+        $this->norm = new Normaliser;
+    }
+
+    public function testNormaliseConfNameStripsExtension()
+    {
+        $this->assertSame(
+            'foo_module',
+            $this->norm->normaliseConfName('foo_module.conf')
+        );
+        $this->assertSame(
+            'foo_module',
+            $this->norm->normaliseConfName('foo_module')
+        );
+    }
+
+    public function testNormaliseConfFilenameAddsExtension()
+    {
+        $this->assertSame(
+            'foo_module.conf',
+            $this->norm->normaliseConfFilename('foo_module')
+        );
+        $this->assertSame(
+            'foo_module.conf',
+            $this->norm->normaliseConfFilename('foo_module.conf')
+        );
+    }
+}


### PR DESCRIPTION
For review.

```
phpunit --testdox

Droid\Test\Plugin\Apache\Command\ApacheModuleDisableCommand
 [x] Apache mod disable throws runtime exception with unknown module
 [x] Apache mod disable exits when module is already disabled
 [x] Apache mod disable throws runtime exception when fails to disable
 [x] Apache mod disable will disable enabled module
 [x] Apache mod disable will report only in check mode

Droid\Test\Plugin\Apache\Command\ApacheModuleEnableCommand
 [x] Apache mod enable throws runtime exception with unknown module
 [x] Apache mod enable exits when module is already enabled
 [x] Apache mod enable throws runtime exception when fails to enable
 [x] Apache mod enable will enable disabled module
 [x] Apache mod enable will report only in check mode

Droid\Test\Plugin\Apache\Command\ApacheSiteDisableCommand
 [x] Apache site disable throws runtime exception with unknown site
 [x] Apache site disable exits when site is already disabled
 [x] Apache site disable throws runtime exception when fails to disable
 [x] Apache site disable will disable enabled site
 [x] Apache site disable will report only in check mode

Droid\Test\Plugin\Apache\Command\ApacheSiteEnableCommand
 [x] Apache site enable throws runtime exception with unknown site
 [x] Apache site enable exits when site is already enabled
 [x] Apache site enable throws runtime exception when fails to enable
 [x] Apache site enable will enable disabled site
 [x] Apache site enable will report only in check mode

Droid\Test\Plugin\Apache\DroidPlugin
 [x] Get commands returns all commands

Droid\Test\Plugin\Apache\Util\Normaliser
 [x] Normalise conf name strips extension
 [x] Normalise conf filename adds extension
```
